### PR TITLE
Add support for parallel testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ go:
   - 1.6
 
 install:
-  - go get golang.org/x/tools/cmd/vet
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/golang/lint/golint

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: required
 language: go
 
 go:
-  - 1.5
-  - 1.6
+  - 1.8
 
 install:
   - go get github.com/mattn/goveralls

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -65,16 +65,18 @@ var (
 // If forcePull is true, it attempts do pull newer versions of the images.
 // If rmFirst is true, it attempts to kill and delete containers before starting new ones.
 func Start(dockerComposeYML string, forcePull, rmFirst bool) (*Compose, error) {
-	return startInternal(dockerComposeYML, forcePull, rmFirst, "compose")
+	return StartProject(dockerComposeYML, forcePull, rmFirst, "compose")
 }
 
 // StartParallel starts a Docker Compose configuration and is suitable for concurrent usage.
-// Note that the services should not bind to localhost ports.
+// The project name is defined at random to ensure multiple instances can be run.
+// Note: that the docker services should not bind to localhost ports.
 func StartParallel(dockerComposeYML string, forcePull bool) (*Compose, error) {
-	return startInternal(dockerComposeYML, forcePull, false, randStringBytes(9))
+	return StartProject(dockerComposeYML, forcePull, false, randStringBytes(9))
 }
 
-func startInternal(dockerComposeYML string, forcePull, rmFirst bool, projectName string) (*Compose, error) {
+// StartProject starts a Docker Compose configuration, giving fine grained control of all of the properties.
+func StartProject(dockerComposeYML string, forcePull, rmFirst bool, projectName string) (*Compose, error) {
 
 	logger.Println("initializing...")
 

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -71,7 +71,7 @@ func Start(dockerComposeYML string, forcePull, rmFirst bool) (*Compose, error) {
 // StartParallel starts a Docker Compose configuration and is suitable for concurrent usage.
 // Note that the services should not bind to localhost ports.
 func StartParallel(dockerComposeYML string, forcePull bool) (*Compose, error) {
-	return startInternal(dockerComposeYML, forcePull, false, RandStringBytes(9))
+	return startInternal(dockerComposeYML, forcePull, false, randStringBytes(9))
 }
 
 func startInternal(dockerComposeYML string, forcePull, rmFirst bool, projectName string) (*Compose, error) {
@@ -144,7 +144,7 @@ func (c *Compose) GetPublicIPAddressForService(serviceName string) (bool, string
 		// look in NetworkSettings.Networks
 		for _, network := range container.NetworkSettings.Networks {
 
-			// iterate networks
+			// iterate aliases looking for the service
 			sort.Strings(network.Aliases)
 			i := sort.SearchStrings(network.Aliases, serviceName)
 

--- a/compose/container.go
+++ b/compose/container.go
@@ -54,6 +54,7 @@ type PortBinding struct {
 	HostPort string `json:"HostPort,omitempty"`
 }
 
+// Network models  the network section of the `docker inspect` command.
 type Network struct {
 	IPAddress string   `json:"IPAddress"`
 	Aliases   []string `json:"Aliases"`

--- a/compose/container.go
+++ b/compose/container.go
@@ -44,13 +44,19 @@ type State struct {
 
 // NetworkSettings models the network settings section of the `docker inspect` command.
 type NetworkSettings struct {
-	Ports map[string][]PortBinding `json:"Ports,omitempty"`
+	Ports    map[string][]PortBinding `json:"Ports,omitempty"`
+	Networks map[string]Network       `json:"Networks"`
 }
 
 // PortBinding models a port binding in the network settings section of the `docker inspect command.
 type PortBinding struct {
 	HostIP   string `json:"HostIP,omitempty"`
 	HostPort string `json:"HostPort,omitempty"`
+}
+
+type Network struct {
+	IPAddress string   `json:"IPAddress"`
+	Aliases   []string `json:"Aliases"`
 }
 
 // Inspect inspects a container using the `docker inspect` command and returns a parsed version of its output.

--- a/compose/utils.go
+++ b/compose/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"regexp"
@@ -37,6 +38,7 @@ func MustInferDockerHost() string {
 
 func runCmd(name string, args ...string) (string, error) {
 	var outBuf bytes.Buffer
+
 	cmd := exec.Command(name, args...)
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &outBuf
@@ -50,6 +52,7 @@ func runCmd(name string, args ...string) (string, error) {
 
 func writeTmp(content string) (string, error) {
 	f, err := ioutil.TempFile("", "docker-compose-")
+
 	if err != nil {
 		return "", fmt.Errorf("compose: error creating temp file: %v", err)
 	}
@@ -60,4 +63,14 @@ func writeTmp(content string) (string, error) {
 	}
 
 	return f.Name(), nil
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
 }

--- a/compose/utils.go
+++ b/compose/utils.go
@@ -67,7 +67,7 @@ func writeTmp(content string) (string, error) {
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-func RandStringBytes(n int) string {
+func randStringBytes(n int) string {
 	b := make([]byte, n)
 	for i := range b {
 		b[i] = letterBytes[rand.Intn(len(letterBytes))]


### PR DESCRIPTION
Hey,

For a new project I wanted to add an ability to run tests against a docker-compose file in parallel. 

To that aim I've added to the public api 

// starts a compose with a random project name
func StartParallel(dockerComposeYML string, forcePull bool) (*Compose, error) 
func MustStartParallel(dockerComposeYML string, forcePull bool) (*Compose, error) 

// for a Compose gets the public IPAddress for a service
func(c *Compose) GetPublicIPAddressForService(serviceName string) (bool,string) 
func(c *Compose) MustGetPublicIPAddressForService(serviceName string) string 

Usage -

```golang
func TestOne(t *testing.T) {
        t.Parallel()

	composeYML := `version: '2'
services:
  mqtt:
    image: erlio/docker-vernemq
    environment:
      - DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on`

	c := compose.MustStartParallel(composeYML, false)
	defer c.Kill()
        ...
        mqttAddress := fmt.Sprintf("tcp://%s:1883", c.MustGetPublicIPAddressForService("mqtt"))
        ...
}
```
The existing public api methods all remain unchanged both in contract. Calling Start and/or MustStart hard code the docker-compose project to the existing name.

The only 'here be dragons' point worth mentioning is that if your docker-compose file binds to ports on the localhost, starting in parallel fails.

It would be great to get some feedback?

Thanks,

Mark
